### PR TITLE
[LF-214] fix: 컨벤션에 맞게 api수정

### DIFF
--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -75,12 +75,12 @@ export const API_ENDPOINTS = {
   },
 
   GUIDE: {
-    POST: "/guide/ask", // POST
+    POST: "/guide", // POST
   },
 
   FAQ: {
     GET: "/core/faq", // GET
-    POST: "/guide/ask",
+    POST: "/guide",
   },
   LEVEL_TEST: {
     GET_QUESTIONS: "/student/leveltest/questions/generate",


### PR DESCRIPTION
/guide/ask되있는걸 /guide로 하였습니다.
그런데 

```
FAQ: {
    GET: "/core/faq", // GET
    POST: "/guide",
  },
```
여기서 FAQ.POST는 사용하는건가요? 
```
GUIDE: {
    POST: "/guide", // POST
  },
```
이거랑 같은 api라 둘중하나로 통일해야 할 것 같습니다.