### PR TITLE
HOTFIX 비로그인 판별조건수정

### DIFF
--- a/src/components/Admin/LoginGuard.tsx
+++ b/src/components/Admin/LoginGuard.tsx
@@ -14,7 +14,8 @@ const LoginGuard = ({ children }: LoginGuardProps) => {
     const memberId = useSelector((state: RootState) => state.auth.memberId);
 
     useEffect(() => {
-        if (!memberId) {
+        // 없는게 아니라 -1이면 비로그인 상태다.
+        if (memberId == -1) {
             alert("로그인시 이용가능합니다");
             navigate(PAGE_PATHS.LOGIN, { replace: true });
         }

--- a/src/components/Admin/LoginGuard.tsx
+++ b/src/components/Admin/LoginGuard.tsx
@@ -15,7 +15,7 @@ const LoginGuard = ({ children }: LoginGuardProps) => {
 
     useEffect(() => {
         // 없는게 아니라 -1이면 비로그인 상태다.
-        if (memberId == -1) {
+        if (memberId === -1) {
             alert("로그인시 이용가능합니다");
             navigate(PAGE_PATHS.LOGIN, { replace: true });
         }


### PR DESCRIPTION
redux에서 auth의 memberId가 아예 없을 때가 아닌 -1일 때로 수정