### PR TITLE
[LF-312] 강의 상세 및 강의, 강좌 등록 페이지  수정

### DIFF
--- a/src/components/CreateLecture/ImageUploader.tsx
+++ b/src/components/CreateLecture/ImageUploader.tsx
@@ -183,7 +183,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onFileSelect }) => {
 
     setOriginalImage({ file, preview });
     setCroppedImage(null);
-    setIsModalOpen(false);
+    setIsModalOpen(true);
 
     onFileSelect(file, preview);
 

--- a/src/components/LectureInfo/AddReviewModal.tsx
+++ b/src/components/LectureInfo/AddReviewModal.tsx
@@ -153,7 +153,6 @@ const AddReviewModal: React.FC<AddReviewModalProps> = ({
 
     setErrors(newErrors);
 
-    // 오류가 있으면 제출 막기
     if (Object.values(newErrors).some((e) => e !== "")) return;
 
     const payload = {
@@ -168,7 +167,8 @@ const AddReviewModal: React.FC<AddReviewModalProps> = ({
     };
 
     onSubmit(payload);
-    onClose();
+
+    handleCancel();
   };
 
   return (

--- a/src/components/LectureInfo/LectureInfoHeader.tsx
+++ b/src/components/LectureInfo/LectureInfoHeader.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useSelector } from "react-redux";
+import type { RootState } from "../../redux/store";
 import {
   faCircleCheck,
   faCircleXmark,
@@ -172,6 +174,9 @@ const LectureInfoHeader: React.FC<LectureHeaderProps> = ({
   purchased,
   progress,
 }) => {
+  const isAuthenticated = useSelector(
+    (state: RootState) => state.token.isAuthenticated
+  );
   const [modalOpen, setModalOpen] = useState(false);
   const [modalMessage, setModalMessage] = useState("");
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
@@ -187,7 +192,7 @@ const LectureInfoHeader: React.FC<LectureHeaderProps> = ({
         price: lecture.price,
         thumbnailUrl: lecture.thumbnail,
       });
-setModalMessage("장바구니 담기 성공");
+      setModalMessage("장바구니 담기 성공");
       setIsSuccess(true);
       setModalOpen(true);
     } catch (err: unknown) {
@@ -215,11 +220,13 @@ setModalMessage("장바구니 담기 성공");
             <ButtonRow>
               <Price>{lecture?.price?.toLocaleString() ?? 0}원</Price>
               <div style={{ marginLeft: "auto", display: "flex", gap: "1rem" }}>
-                <Button
-                  text="장바구니에 추가"
-                  onClick={handleAddCart}
-                  design={1}
-                />
+                {isAuthenticated && (
+                  <Button
+                    text="장바구니에 추가"
+                    onClick={handleAddCart}
+                    design={1}
+                  />
+                )}
               </div>
             </ButtonRow>
           ) : (
@@ -281,7 +288,7 @@ setModalMessage("장바구니 담기 성공");
               {isSuccess ? "성공" : "실패"}
             </h2>
             <p>{modalMessage}</p>
-<div style={{ display: "flex", gap: "1rem", marginTop: "1rem" }}>
+            <div style={{ display: "flex", gap: "1rem", marginTop: "1rem" }}>
               {isSuccess ? (
                 <>
                   <Button

--- a/src/components/LectureInfo/LectureInfoHeader.tsx
+++ b/src/components/LectureInfo/LectureInfoHeader.tsx
@@ -167,12 +167,14 @@ interface LectureHeaderProps {
   lecture: LectureResponse | undefined;
   purchased: boolean | undefined;
   progress: number;
+  hasLessons?: boolean;
 }
 
 const LectureInfoHeader: React.FC<LectureHeaderProps> = ({
   lecture,
   purchased,
   progress,
+  hasLessons,
 }) => {
   const isAuthenticated = useSelector(
     (state: RootState) => state.token.isAuthenticated
@@ -268,6 +270,7 @@ const LectureInfoHeader: React.FC<LectureHeaderProps> = ({
                 }
                 design={2}
                 fontWeight={700}
+                disabled={!hasLessons}
               />
             </ButtonRow>
           )}

--- a/src/components/LessonManagement/LessonContainer.tsx
+++ b/src/components/LessonManagement/LessonContainer.tsx
@@ -95,7 +95,6 @@ const LessonContainer: React.FC<Props> = ({
           <div>순서</div>
           <div>강좌</div>
           <div>생성 일자</div>
-          <div>액션</div>
         </HeaderRow>
 
         {lessons.map((lesson, idx) => (

--- a/src/pages/CreateLecturePage/CreateLecturePage.tsx
+++ b/src/pages/CreateLecturePage/CreateLecturePage.tsx
@@ -220,11 +220,10 @@ const SectionSubtitle = styled.p`
 const ConfirmRow = styled.div`
   margin-bottom: 12px;
   font-size: ${({ theme }) => theme.fontSize.body.min};
-
   strong {
     font-weight: 600;
     display: inline-block;
-    width: 90px;
+    min-width: 65px;
   }
 `;
 

--- a/src/pages/CreateLecturePage/CreateLecturePage.tsx
+++ b/src/pages/CreateLecturePage/CreateLecturePage.tsx
@@ -233,6 +233,7 @@ const CreateLecturePage = () => {
 
   const navigate = useNavigate();
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
   const [selectedInterests, setSelectedInterests] = useState<Interest[]>([]);
@@ -495,14 +496,18 @@ const CreateLecturePage = () => {
               <Button
                 text="취소"
                 onClick={() => setShowConfirmModal(false)}
+                disabled={isSubmitting}
                 design={1}
               />
               <Button
-                text="제출"
+                text={isSubmitting ? "제출 중..." : "제출"}
                 onClick={async () => {
+                  if (isSubmitting) return;
+                  setIsSubmitting(true);
                   try {
                     if (selectedImageFile == null || selectedFile == null)
                       return;
+
                     const response = await openLectureRequest({
                       title,
                       category: selectedInterests[0]?.name ?? "",
@@ -524,9 +529,12 @@ const CreateLecturePage = () => {
                     navigate(PAGE_PATHS.USER_PAGE.LECTURER.MAIN);
                   } catch (error) {
                     console.error("강의 개설 중 오류 발생:", error);
-                    alert("강의 개설 중 오류 발생");
+                    alert(error);
+                  } finally {
+                    setIsSubmitting(false);
                   }
                 }}
+                disabled={isSubmitting}
                 design={1}
               />
             </div>

--- a/src/pages/LectureInfoPage/LectureInfoPage.tsx
+++ b/src/pages/LectureInfoPage/LectureInfoPage.tsx
@@ -202,6 +202,7 @@ const LectureInfoPage = () => {
         lecture={lecture?.lectureResponseDto}
         purchased={lecture?.isStudent}
         progress={progress}
+        hasLessons={lessonList.length > 0}
       />
 
       <LectureInfoTabMenu


### PR DESCRIPTION
## 작업 내용
    - 수강평 제출시 리셋 처리
    - 강의 상세 페이지 비회원은 장바구니 접근 불가하도록 처리
    -  강좌 등록 페이지 헤더에 액션 빼기
    - 강의 출시 모달 만들기
    - 강좌 없을 시 강좌 들으러가기 막기
    - 강의 개설 제출 버튼 한번만 눌리게 조절하기
    - 강의 개설 모달 값과 간격 조정하기
    - 썸네일 조정 이미지 바꿨을때도 뜨게 처리