### PR TITLE
fix: 장바구니 이미지 정상 출력

### DIFF
--- a/src/components/Payment/ProductList.tsx
+++ b/src/components/Payment/ProductList.tsx
@@ -181,6 +181,7 @@ const Thumb = styled.div<{ imageUrl?: string }>`
 
   &::before {
     content: "";
+    display: block;
     top: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
<img width="838" height="404" alt="image" src="https://github.com/user-attachments/assets/8af8ea21-518a-49cb-8665-67844c2484f5" />
